### PR TITLE
added summary sensor

### DIFF
--- a/custom_components/uptime_kuma/sensor.py
+++ b/custom_components/uptime_kuma/sensor.py
@@ -50,6 +50,17 @@ async def async_setup_entry(
         )
         for monitor in coordinator.data
     )
+    async_add_entities(
+        [UptimeKumaSummarySensor(
+            coordinator,
+            SensorEntityDescription(
+                key="system_summary",
+                name="system_summary",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                device_class="uptimekuma__monitor_status",
+            )
+        )]
+    )
 
 
 class UptimeKumaSensor(UptimeKumaEntity, SensorEntity):
@@ -76,3 +87,35 @@ class UptimeKumaSensor(UptimeKumaEntity, SensorEntity):
     def icon(self) -> str:
         """Return the status of the monitor."""
         return SENSORS_INFO[self.monitor.monitor_status]["icon"]
+
+
+class UptimeKumaSummarySensor(SensorEntity):
+    """Representation of a UptimeKuma sensor."""
+
+    def __init__(
+        self,
+        coordinator: UptimeKumaDataUpdateCoordinator,
+        description: EntityDescription
+    ) -> None:
+        """Set entity ID."""
+        super().__init__()
+        self.description=description
+        self.coordinator=coordinator
+        self.ukstate=0.0
+        self.entity_id = (
+            f"sensor.uptimekuma_{format_entity_name(self.description.name)}"
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the status of the monitor."""
+        self.ukstate=1.0
+        for m in self.coordinator.data:
+            if m.monitor_status == 0.0:
+                self.ukstate=0.0
+        return SENSORS_INFO[self.ukstate]["value"]
+
+    @property
+    def icon(self) -> str:
+        """Return the status of the monitor."""
+        return SENSORS_INFO[self.ukstate]["icon"]


### PR DESCRIPTION
as discussed in https://github.com/meichthys/uptime_kuma/issues/29

Summary sensors are possible in Home Assistant, but flexible groups with wildcards require additional custom components, or significant templating. A simple sensor that automatically considers all uptime kuma instances without additional configuration is helpful. 

Implementation is simple enough, but yes, maintenance might be required in future. I will support if I can, but I leave the decision to integrate this to @meichthys.