### PR TITLE
added error caching option

### DIFF
--- a/custom_components/uptime_kuma/const.py
+++ b/custom_components/uptime_kuma/const.py
@@ -14,6 +14,7 @@ COORDINATOR_UPDATE_INTERVAL: timedelta = timedelta(seconds=10)
 
 DOMAIN = "uptime_kuma"
 PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
+ERROR_CACHE_SIZE = 1
 
 ATTRIBUTION: Final = "Data provided by Uptime Kuma"
 


### PR DESCRIPTION
Here is something rather controversial: My (and it seems others') Uptime Kuma has performance issues. This seems to be a common thing, unfortunately. Every once-in-a-while (usually once every 2-5min) it does not load immediately, but runs into a rather long timeout, leading to a rather spotty coverage in Home Assistant, despite monitors being updated and checked:
![grafik](https://github.com/meichthys/uptime_kuma/assets/4414560/3b79003c-5a88-4fda-9198-7af65cba8cef)

Of course, the proper way to deal with this is fixing Uptime Kuma. However, it seems there are over 800 open issues and more than 70 pull requests, so I don't forsee this happening any time soon. I would like to work around this here in a simple manner.

My approach: In case a connection can't be established a defined number of times, don't immediately throw an exception, but rather return cached values. Only if connection errors persist, throw error. This is the controversial part, as errors that actually happen are hidden.

Currently, the value for the cache size is hard-coded to a value that works for my setup. I tried to make this configurable via config flow, but failed. Might need some help here.